### PR TITLE
Compaction Status and Average Row Size

### DIFF
--- a/collector/druid.go
+++ b/collector/druid.go
@@ -32,6 +32,26 @@ func GetDruidHealthMetrics() float64 {
 	return utils.GetHealth(druidHealthURL)
 }
 
+// GetDruidCompactionData returns the datasources compaction data
+func GetDruidCompactionData() CompactionStatusInterface {
+	kingpin.Parse()
+	druidCompactionStatusURL := *druid + compactionStatusURL
+	responseData, err := utils.GetResponse(druidCompactionStatusURL, "Compaction")
+	if err != nil {
+		logrus.Errorf("Cannot collect data for druid compaction status: %v", err)
+		return nil
+	}
+	logrus.Debugf("Successfully collected the data for druid compaction status")
+	var metric map[string]CompactionStatusInterface
+	err = json.Unmarshal(responseData, &metric)
+	if err != nil {
+		logrus.Errorf("Cannot parse JSON data: %v", err)
+		return nil
+	}
+	logrus.Debugf("Druid compaction status data, %v", metric)
+	return metric["latestStatus"]
+}
+
 // GetDruidSegmentData returns the datasources of druid
 func GetDruidSegmentData() SegementInterface {
 	kingpin.Parse()
@@ -167,6 +187,9 @@ func (collector *MetricCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- collector.DruidWaitingTasks
 	ch <- collector.DruidCompletedTasks
 	ch <- collector.DruidPendingTasks
+	ch <- collector.DruidBytesCompaction
+	ch <- collector.DruidSegmentCountCompaction
+	ch <- collector.DruidIntervalCountCompaction
 }
 
 // Collector return the defined metrics
@@ -239,6 +262,15 @@ func Collector() *MetricCollector {
 				Help: "Druid task errors",
 			},
 			[]string{"error_msg"},
+		),
+		DruidBytesCompaction: prometheus.NewDesc("druid_bytes_compaction",
+			"Druid Bytes compaction", []string{"datasource"}, nil,
+		),
+		DruidSegmentCountCompaction: prometheus.NewDesc("druid_segment_count_compaction",
+			"Druid Segment Count Compaction", []string{"datasource"}, nil,
+		),
+		DruidIntervalCountCompaction: prometheus.NewDesc("druid_interval_count_compaction",
+			"Druid Interval Count Compaction", []string{"datasource"}, nil,
 		),
 	}
 }
@@ -332,6 +364,17 @@ func (collector *MetricCollector) Collect(ch chan<- prometheus.Metric) {
 
 	for _, data := range GetDruidDataSourcesTotalRows(sqlURL) {
 		ch <- prometheus.MustNewConstMetric(collector.DruidDataSourcesTotalRows, prometheus.GaugeValue, float64(data.TotalRows), data.Datasource, data.Source)
+	}
+
+	for _, data := range GetDruidCompactionData() {
+		b := data.BytesCompacted * 100 / (data.BytesCompacted + data.BytesAwaitingCompaction)
+		ch <- prometheus.MustNewConstMetric(collector.DruidBytesCompaction, prometheus.GaugeValue, b, data.DataSource)
+
+		sc := data.SegmentCountCompacted * 100 / (data.SegmentCountCompacted + data.SegmentCountAwaitingCompaction)
+		ch <- prometheus.MustNewConstMetric(collector.DruidSegmentCountCompaction, prometheus.GaugeValue, sc, data.DataSource)
+
+		ic := data.IntervalCountCompacted * 100 / (data.IntervalCountCompacted + data.IntervalCountAwaitingCompaction)
+		ch <- prometheus.MustNewConstMetric(collector.DruidIntervalCountCompaction, prometheus.GaugeValue, ic, data.DataSource)
 	}
 }
 

--- a/collector/druid.go
+++ b/collector/druid.go
@@ -173,6 +173,26 @@ func getDruidWorkersData(pathURL string) []worker {
 	return workers
 }
 
+// GetDruidDataSourcesAverageRowSize returns the amount of rows in each datasource
+func GetDruidDataSourcesAverageRowSize(pathURL string) DataSourcesAvgRowSize {
+	kingpin.Parse()
+	druidURL := *druid + pathURL
+	responseData, err := utils.GetSQLResponse(druidURL, avgRowSize)
+	if err != nil {
+		logrus.Errorf("Cannot retrieve data for druid's datasources rows: %v", err)
+		return nil
+	}
+	logrus.Debugf("Successfully retrieved the data for druid's datasources rows")
+	var datasources DataSourcesAvgRowSize
+	err = json.Unmarshal(responseData, &datasources)
+	if err != nil {
+		logrus.Errorf("Cannot parse JSON data: %v", err)
+		return nil
+	}
+	logrus.Debugf("Druid datasources avg row size, %v", datasources)
+	return datasources
+}
+
 // Describe will associate the value for druid exporter
 func (collector *MetricCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- collector.DruidHealthStatus
@@ -190,6 +210,7 @@ func (collector *MetricCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- collector.DruidBytesCompaction
 	ch <- collector.DruidSegmentCountCompaction
 	ch <- collector.DruidIntervalCountCompaction
+	ch <- collector.DruidDataSourcesAverageRowSize
 }
 
 // Collector return the defined metrics
@@ -232,6 +253,10 @@ func Collector() *MetricCollector {
 		DruidDataSourcesTotalRows: prometheus.NewDesc("druid_datasource_total_rows",
 			"Number of rows in a datasource",
 			[]string{"datasource_name", "source"}, nil),
+		DruidDataSourcesAverageRowSize: prometheus.NewDesc("druid_datasource_average_row_size",
+			"Average Row Size in a datasource",
+			[]string{"datasource"}, nil,
+		),
 		DruidRunningTasks: prometheus.NewDesc("druid_running_tasks",
 			"Druid running tasks count",
 			nil, nil,
@@ -264,13 +289,16 @@ func Collector() *MetricCollector {
 			[]string{"error_msg"},
 		),
 		DruidBytesCompaction: prometheus.NewDesc("druid_bytes_compaction",
-			"Druid Bytes compaction", []string{"datasource"}, nil,
+			"Druid Bytes compaction",
+			[]string{"datasource"}, nil,
 		),
 		DruidSegmentCountCompaction: prometheus.NewDesc("druid_segment_count_compaction",
-			"Druid Segment Count Compaction", []string{"datasource"}, nil,
+			"Druid Segment Count Compaction",
+			[]string{"datasource"}, nil,
 		),
 		DruidIntervalCountCompaction: prometheus.NewDesc("druid_interval_count_compaction",
-			"Druid Interval Count Compaction", []string{"datasource"}, nil,
+			"Druid Interval Count Compaction",
+			[]string{"datasource"}, nil,
 		),
 	}
 }
@@ -364,6 +392,10 @@ func (collector *MetricCollector) Collect(ch chan<- prometheus.Metric) {
 
 	for _, data := range GetDruidDataSourcesTotalRows(sqlURL) {
 		ch <- prometheus.MustNewConstMetric(collector.DruidDataSourcesTotalRows, prometheus.GaugeValue, float64(data.TotalRows), data.Datasource, data.Source)
+	}
+
+	for _, data := range GetDruidDataSourcesAverageRowSize(sqlURL) {
+		ch <- prometheus.MustNewConstMetric(collector.DruidDataSourcesAverageRowSize, prometheus.GaugeValue, float64(data.AvgRowSize), data.Datasource)
 	}
 
 	for _, data := range GetDruidCompactionData() {

--- a/collector/interface.go
+++ b/collector/interface.go
@@ -27,27 +27,44 @@ from sys.segments SEG
 inner join sys.supervisors SUP ON SEG.datasource=SUP.supervisor_id
 group by SEG.datasource, SUP.source`
 
+const avgRowSize = `SELECT datasource,
+	CASE WHEN
+	 SUM("num_rows") FILTER (WHERE is_published = 1 AND is_overshadowed = 0) <> 0
+	THEN
+	 (SUM("size") FILTER (WHERE is_published = 1 AND is_overshadowed = 0) / SUM("num_rows") FILTER (WHERE is_published = 1 AND is_overshadowed = 0))
+	ELSE 0
+	END AS avg_row_size
+FROM sys.segments
+GROUP BY 1 ORDER BY 1`
+
 // MetricCollector includes the list of metrics
 type MetricCollector struct {
-	DruidHealthStatus            *prometheus.Desc
-	DataSourceCount              *prometheus.Desc
-	DruidWorkers                 *prometheus.Desc
-	DruidTasks                   *prometheus.Desc
-	DruidSupervisors             *prometheus.Desc
-	DruidSegmentCount            *prometheus.Desc
-	DruidSegmentSize             *prometheus.Desc
-	DruidSegmentReplicateSize    *prometheus.Desc
-	DruidDataSourcesTotalRows    *prometheus.Desc
-	DruidRunningTasks            *prometheus.Desc
-	DruidWaitingTasks            *prometheus.Desc
-	DruidCompletedTasks          *prometheus.Desc
-	DruidPendingTasks            *prometheus.Desc
-	DruidFailedTasks             *prometheus.Desc
-	DruidTaskCapacity            *prometheus.Desc
-	DruidTaskErrors              *prometheus.GaugeVec
-	DruidBytesCompaction         *prometheus.Desc
-	DruidSegmentCountCompaction  *prometheus.Desc
-	DruidIntervalCountCompaction *prometheus.Desc
+	DruidHealthStatus              *prometheus.Desc
+	DataSourceCount                *prometheus.Desc
+	DruidWorkers                   *prometheus.Desc
+	DruidTasks                     *prometheus.Desc
+	DruidSupervisors               *prometheus.Desc
+	DruidSegmentCount              *prometheus.Desc
+	DruidSegmentSize               *prometheus.Desc
+	DruidSegmentReplicateSize      *prometheus.Desc
+	DruidDataSourcesTotalRows      *prometheus.Desc
+	DruidDataSourcesAverageRowSize *prometheus.Desc
+	DruidRunningTasks              *prometheus.Desc
+	DruidWaitingTasks              *prometheus.Desc
+	DruidCompletedTasks            *prometheus.Desc
+	DruidPendingTasks              *prometheus.Desc
+	DruidFailedTasks               *prometheus.Desc
+	DruidTaskCapacity              *prometheus.Desc
+	DruidTaskErrors                *prometheus.GaugeVec
+	DruidBytesCompaction           *prometheus.Desc
+	DruidSegmentCountCompaction    *prometheus.Desc
+	DruidIntervalCountCompaction   *prometheus.Desc
+}
+
+// DataSourcesAvgRowSize shows average row size from each datasource
+type DataSourcesAvgRowSize []struct {
+	Datasource string `json:"datasource"`
+	AvgRowSize int64  `json:"avg_row_size"`
 }
 
 // DataSourcesTotalRows shows total rows from each datasource

--- a/collector/interface.go
+++ b/collector/interface.go
@@ -8,16 +8,17 @@ import (
 )
 
 const (
-	healthURL      = "/status/health"
-	segmentDataURL = "/druid/coordinator/v1/datasources?simple"
-	tasksURL       = "/druid/indexer/v1/tasks"
-	workersURL     = "/druid/indexer/v1/workers"
-	supervisorURL  = "/druid/indexer/v1/supervisor?full"
-	sqlURL         = "/druid/v2/sql"
-	pendingTask    = "/druid/indexer/v1/pendingTasks"
-	runningTask    = "/druid/indexer/v1/runningTasks"
-	waitingTask    = "/druid/indexer/v1/waitingTasks"
-	completedTask  = "/druid/indexer/v1/completeTasks"
+	healthURL           = "/status/health"
+	segmentDataURL      = "/druid/coordinator/v1/datasources?simple"
+	tasksURL            = "/druid/indexer/v1/tasks"
+	workersURL          = "/druid/indexer/v1/workers"
+	supervisorURL       = "/druid/indexer/v1/supervisor?full"
+	sqlURL              = "/druid/v2/sql"
+	pendingTask         = "/druid/indexer/v1/pendingTasks"
+	runningTask         = "/druid/indexer/v1/runningTasks"
+	waitingTask         = "/druid/indexer/v1/waitingTasks"
+	completedTask       = "/druid/indexer/v1/completeTasks"
+	compactionStatusURL = "/druid/coordinator/v1/compaction/status"
 )
 
 const totalRowsSQL = `select SEG.datasource, SUP.source,
@@ -28,22 +29,25 @@ group by SEG.datasource, SUP.source`
 
 // MetricCollector includes the list of metrics
 type MetricCollector struct {
-	DruidHealthStatus         *prometheus.Desc
-	DataSourceCount           *prometheus.Desc
-	DruidWorkers              *prometheus.Desc
-	DruidTasks                *prometheus.Desc
-	DruidSupervisors          *prometheus.Desc
-	DruidSegmentCount         *prometheus.Desc
-	DruidSegmentSize          *prometheus.Desc
-	DruidSegmentReplicateSize *prometheus.Desc
-	DruidDataSourcesTotalRows *prometheus.Desc
-	DruidRunningTasks         *prometheus.Desc
-	DruidWaitingTasks         *prometheus.Desc
-	DruidCompletedTasks       *prometheus.Desc
-	DruidPendingTasks         *prometheus.Desc
-	DruidFailedTasks          *prometheus.Desc
-	DruidTaskCapacity         *prometheus.Desc
-	DruidTaskErrors           *prometheus.GaugeVec
+	DruidHealthStatus            *prometheus.Desc
+	DataSourceCount              *prometheus.Desc
+	DruidWorkers                 *prometheus.Desc
+	DruidTasks                   *prometheus.Desc
+	DruidSupervisors             *prometheus.Desc
+	DruidSegmentCount            *prometheus.Desc
+	DruidSegmentSize             *prometheus.Desc
+	DruidSegmentReplicateSize    *prometheus.Desc
+	DruidDataSourcesTotalRows    *prometheus.Desc
+	DruidRunningTasks            *prometheus.Desc
+	DruidWaitingTasks            *prometheus.Desc
+	DruidCompletedTasks          *prometheus.Desc
+	DruidPendingTasks            *prometheus.Desc
+	DruidFailedTasks             *prometheus.Desc
+	DruidTaskCapacity            *prometheus.Desc
+	DruidTaskErrors              *prometheus.GaugeVec
+	DruidBytesCompaction         *prometheus.Desc
+	DruidSegmentCountCompaction  *prometheus.Desc
+	DruidIntervalCountCompaction *prometheus.Desc
 }
 
 // DataSourcesTotalRows shows total rows from each datasource
@@ -103,6 +107,21 @@ type worker struct {
 	}
 	CurrCapacityUsed int      `json:"currCapacityUsed"`
 	RunningTasks     []string `json:"runningTasks"`
+}
+
+// CompactionInterface is the interface for parsing compaction status data
+type CompactionStatusInterface []struct {
+	DataSource                      string  `json:"dataSource"`
+	ScheduleStatus                  string  `json:"scheduleStatus"`
+	BytesAwaitingCompaction         float64 `json:"bytesAwaitingCompaction"`
+	BytesCompacted                  float64 `json:"bytesCompacted"`
+	BytesSkipped                    float64 `json:"bytesSkipped"`
+	SegmentCountAwaitingCompaction  float64 `json:"segmentCountAwaitingCompaction"`
+	SegmentCountCompacted           float64 `json:"segmentCountCompacted"`
+	SegmentCountSkipped             float64 `json:"segmentCountSkipped"`
+	IntervalCountAwaitingCompaction float64 `json:"intervalCountAwaitingCompaction"`
+	IntervalCountCompacted          float64 `json:"intervalCountCompacted"`
+	IntervalCountSkipped            float64 `json:"intervalCountSkipped"`
 }
 
 func (w worker) hostname() string {


### PR DESCRIPTION
# Overview
This PR scrapes *compaction status* from each DataSource, and also provides the average_row_size in each DataSource.

# Implementation

## Compaction Status
The Console shows column '% Compacted' in the form of 'bytes / segments / intervals'. 
These are newly added as Gauges for:
- druid_bytes_compaction
- druid_segment_count_compaction
- druid_interval_count_compaction

These are all *float64* percentages <= 100.0

## DataSource Average Row Size
The Console shows column 'Avg. row size (bytes)' in the form of 'bytes / segments / intervals'. 
This is newly added as Gauge named:
- druid_datasource_average_row_size

# Example Output

```
# HELP druid_datasource_average_row_size Average Row Size in a datasource
# TYPE druid_datasource_average_row_size gauge
druid_datasource_average_row_size{datasource="SpanView"} 442
druid_datasource_average_row_size{datasource="TraceView"} 113

# HELP druid_bytes_compaction Druid Bytes compaction
# TYPE druid_bytes_compaction gauge
druid_bytes_compaction{datasource="SpanView"} 99.96280209646932
druid_bytes_compaction{datasource="TraceView"} 100

# HELP druid_interval_count_compaction Druid Interval Count Compaction
# TYPE druid_interval_count_compaction gauge
druid_interval_count_compaction{datasource="SpanView"} 99.37888198757764
druid_interval_count_compaction{datasource="TraceView"} 100

# HELP druid_segment_count_compaction Druid Segment Count Compaction
# TYPE druid_segment_count_compaction gauge
druid_segment_count_compaction{datasource="SpanView"} 98.5239852398524
druid_segment_count_compaction{datasource="TraceView"} 100
```