### PR TITLE
[new] gauge counter for pending ingest tasks

### DIFF
--- a/collector/interface.go
+++ b/collector/interface.go
@@ -53,6 +53,7 @@ type MetricCollector struct {
 	DruidWaitingTasks              *prometheus.Desc
 	DruidCompletedTasks            *prometheus.Desc
 	DruidPendingTasks              *prometheus.Desc
+	DruidPendingIngestTasks        *prometheus.Desc
 	DruidFailedTasks               *prometheus.Desc
 	DruidTaskCapacity              *prometheus.Desc
 	DruidTaskErrors                *prometheus.GaugeVec
@@ -113,6 +114,7 @@ type TasksInterface []struct {
 type TaskStatusMetric []struct {
 	NameDataSource string `json:"dataSource"`
 	StatusCode     string `json:"statusCode"`
+	Type           string `json:"type"`
 }
 
 type worker struct {


### PR DESCRIPTION
# Overview
We want to know when too many ingest tasks are pending so we can raise an alarm or scale up.

# Modified
Add new guage druid_pending_ingest_tasks , which counts these tasks.