### PR TITLE
gauge counter for running ingest tasks

### DIFF
--- a/collector/druid.go
+++ b/collector/druid.go
@@ -374,7 +374,6 @@ func (collector *MetricCollector) Collect(ch chan<- prometheus.Metric) {
 			runningIngestTaskCount++
 		}
 	}
-	ch <- prometheus.MustNewConstMetric(collector.DruidRunningTasks, prometheus.GaugeValue, float64(len(runningTasks)))
 	ch <- prometheus.MustNewConstMetric(collector.DruidRunningIngestTasks, prometheus.GaugeValue, runningIngestTaskCount)
 
 	workers := getDruidWorkersData(workersURL)

--- a/collector/interface.go
+++ b/collector/interface.go
@@ -56,6 +56,7 @@ type MetricCollector struct {
 	DruidDataSourcesNumSegmentsToLoad *prometheus.Desc
 	DruidDataSourcesNumSegmentsToDrop *prometheus.Desc
 	DruidRunningTasks                 *prometheus.Desc
+	DruidRunningIngestTasks           *prometheus.Desc
 	DruidWaitingTasks                 *prometheus.Desc
 	DruidCompletedTasks               *prometheus.Desc
 	DruidPendingTasks                 *prometheus.Desc


### PR DESCRIPTION
# Overview
We want to know when too many ingest tasks are running so we can raise an alarm or scale up.

# Modified
Add new guage druid_running_ingest_tasks , which counts these tasks.